### PR TITLE
19.4 ignore linting during build

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,10 @@ const eslintConfig = [
   {
     ignores: ["**/generated/*"],
     rules: {
-      "no-unused-vars": "warn",
+      "no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-expressions": "off",
+      "@typescript-eslint/no-this-alias": "off",
     },
   },
 ];

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
 };
 
 export default nextConfig;

--- a/src/inngest/functions.ts
+++ b/src/inngest/functions.ts
@@ -15,8 +15,6 @@ import { FRAGMENT_TITLE_PROMPT, PROMPT, RESPONSE_PROMPT } from "../prompt";
 import z from "zod";
 import { lastAssistantTextMessageContent } from "../lib/utils";
 import { prisma } from "@/lib/db";
-import { Assistant } from "next/font/google";
-import { create } from "domain";
 import { SANDBOX_TIMEOUT } from "./types";
 
 interface AgentState {

--- a/src/modules/messages/server/procedures.ts
+++ b/src/modules/messages/server/procedures.ts
@@ -3,7 +3,6 @@ import { prisma } from "@/lib/db";
 import { consumeCredits } from "@/lib/usage";
 import { protectedProcedure, createTRPCRouter } from "@/trpc/init";
 import { TRPCError } from "@trpc/server";
-import { err } from "inngest/types";
 
 import z from "zod";
 

--- a/src/modules/projects/server/procedures.ts
+++ b/src/modules/projects/server/procedures.ts
@@ -3,7 +3,6 @@ import { prisma } from "@/lib/db";
 import { consumeCredits } from "@/lib/usage";
 import { protectedProcedure, createTRPCRouter } from "@/trpc/init";
 import { TRPCError } from "@trpc/server";
-import { CarTaxiFront } from "lucide-react";
 import { generateSlug } from "random-word-slugs";
 import z from "zod";
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to ignore ESLint errors and warnings during builds.
  * Disabled several ESLint and TypeScript-specific linting rules related to unused variables, expressions, and aliasing.
  * Removed unused imports from various files to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->